### PR TITLE
(fix) reuse ib instance during data pulls

### DIFF
--- a/examples/example_db.py
+++ b/examples/example_db.py
@@ -1,5 +1,5 @@
 from loguru import logger
-from ta_scanner.data import load_data, load_data_ib, prepare_db, load_and_cache
+from ta_scanner.data import load_data, prepare_db, load_and_cache, IbDataFetcher
 
 # from ta_scanner.indicators import IndicatorSmaCrossover, IndicatorParams
 # from ta_scanner.signals import Signal
@@ -9,4 +9,7 @@ from ta_scanner.data import load_data, load_data_ib, prepare_db, load_and_cache
 
 prepare_db()
 
-df = load_and_cache("QQQ", previous_days=10, use_rth=True)
+ib_data_fetcher = IbDataFetcher()
+
+df = load_and_cache("QQQ", ib_data_fetcher, previous_days=10, use_rth=True)
+df = load_and_cache("SPY", ib_data_fetcher, previous_days=10, use_rth=True)

--- a/examples/moving_average_crossover.py
+++ b/examples/moving_average_crossover.py
@@ -1,5 +1,5 @@
 from loguru import logger
-from ta_scanner.data import load_data, load_data_ib
+from ta_scanner.data import load_data, prepare_db, load_and_cache, IbDataFetcher
 from ta_scanner.indicators import IndicatorSmaCrossover, IndicatorParams
 from ta_scanner.signals import Signal
 from ta_scanner.filters import FilterCumsum, FilterOptions, FilterNames
@@ -7,7 +7,9 @@ from ta_scanner.reports import BasicReport
 
 
 # get SPY data
-df = load_data_ib("SPY")
+prepare_db()
+ib_data_fetcher = IbDataFetcher()
+df = load_and_cache("SPY", ib_data_fetcher, previous_days=30, use_rth=True)
 
 indicator_sma_cross = IndicatorSmaCrossover()
 
@@ -16,7 +18,7 @@ field_name = "moving_avg_cross"
 
 # Moving Average Crossover, 20 vs 50
 indicator_params = {
-    IndicatorParams.fast_ema: 20,
+    IndicatorParams.fast_ema: 10,
     IndicatorParams.slow_ema: 50,
 }
 # apply indicator to generate signals

--- a/ta_scanner/models.py
+++ b/ta_scanner/models.py
@@ -1,5 +1,14 @@
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import create_engine, Column, Integer, Numeric, String, DateTime, Index, Boolean
+from sqlalchemy import (
+    create_engine,
+    Column,
+    Integer,
+    Numeric,
+    String,
+    DateTime,
+    Index,
+    Boolean,
+)
 
 
 Base = declarative_base()


### PR DESCRIPTION
When running examples and pulling in data for more than 1 instrument, IB complains that there is an existing Client Id of 1.

To fix this, let's reuse the `ib` client

Let's also enhance the code by lazy initializing the `ib` client only if the data is not found in the DB. This provides users/developers the option of loading the data and running all analysis / simulations offline.

Long term, it would help to break the IB data fetching out into a connector so that users can tap into multiple connectors to populate the DB. I could see myself wanting to pull down BTC, ETH, and BAT data to run simulations on that data too.

To summarize what's in scope, 
- lazy init the `ib` client / python object
- only do this when a user needs to fetch data and this data does not exist in DB