### PR TITLE
data / persistence - agg data into OHLC bars for variable timeframes

### DIFF
--- a/examples/example_db_futures.py
+++ b/examples/example_db_futures.py
@@ -3,7 +3,8 @@ from ta_scanner.data import load_and_cache, IbDataFetcher
 
 ib_data_fetcher = IbDataFetcher()
 
-df = load_and_cache("/MES", ib_data_fetcher, previous_days=20, use_rth=True)
-df = load_and_cache("/MNQ", ib_data_fetcher, previous_days=20, use_rth=True)
-df = load_and_cache("/ZS", ib_data_fetcher, previous_days=30, use_rth=True)
-df = load_and_cache("/MGC", ib_data_fetcher, previous_days=30, use_rth=True)
+df = load_and_cache("/MES", ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15)
+
+# df = load_and_cache("/MNQ", ib_data_fetcher, previous_days=20, use_rth=True)
+# df = load_and_cache("/ZS", ib_data_fetcher, previous_days=30, use_rth=True)
+# df = load_and_cache("/MGC", ib_data_fetcher, previous_days=30, use_rth=True)

--- a/examples/example_db_futures.py
+++ b/examples/example_db_futures.py
@@ -3,8 +3,8 @@ from ta_scanner.data import load_and_cache, IbDataFetcher
 
 ib_data_fetcher = IbDataFetcher()
 
-df = load_and_cache("/MES", ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15)
+future_symbols = ["/MES", "/MNQ", "/ZS", "/GC"]
 
-# df = load_and_cache("/MNQ", ib_data_fetcher, previous_days=20, use_rth=True)
-# df = load_and_cache("/ZS", ib_data_fetcher, previous_days=30, use_rth=True)
-# df = load_and_cache("/MGC", ib_data_fetcher, previous_days=30, use_rth=True)
+for symbol in future_symbols:
+    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1)
+    logger.info(f"{symbol} - {len(df.index)}")

--- a/examples/example_db_futures.py
+++ b/examples/example_db_futures.py
@@ -1,6 +1,7 @@
 from loguru import logger
 from ta_scanner.data import load_and_cache, IbDataFetcher
 
+
 ib_data_fetcher = IbDataFetcher()
 
 future_symbols = ["/MES", "/MNQ", "/ZS", "/GC"]
@@ -8,3 +9,9 @@ future_symbols = ["/MES", "/MNQ", "/ZS", "/GC"]
 for symbol in future_symbols:
     df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1)
     logger.info(f"{symbol} - {len(df.index)}")
+    logger.info(f"{symbol} - first data row = {df.head(1)}")
+
+for symbol in future_symbols:
+    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1, return_tz="US/Mountain")
+    logger.info(f"{symbol} - {len(df.index)}")
+    logger.info(f"{symbol} - first data row = {df.head(1)}")

--- a/examples/example_db_futures.py
+++ b/examples/example_db_futures.py
@@ -7,11 +7,20 @@ ib_data_fetcher = IbDataFetcher()
 future_symbols = ["/MES", "/MNQ", "/ZS", "/GC"]
 
 for symbol in future_symbols:
-    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1)
+    df = load_and_cache(
+        symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1
+    )
     logger.info(f"{symbol} - {len(df.index)}")
     logger.info(f"{symbol} - first data row = {df.head(1)}")
 
 for symbol in future_symbols:
-    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1, return_tz="US/Mountain")
+    df = load_and_cache(
+        symbol,
+        ib_data_fetcher,
+        previous_days=20,
+        use_rth=False,
+        groupby_minutes=1,
+        return_tz="US/Mountain",
+    )
     logger.info(f"{symbol} - {len(df.index)}")
     logger.info(f"{symbol} - first data row = {df.head(1)}")

--- a/examples/example_db_stocks.py
+++ b/examples/example_db_stocks.py
@@ -3,5 +3,8 @@ from ta_scanner.data import load_and_cache, IbDataFetcher
 
 ib_data_fetcher = IbDataFetcher()
 
-df = load_and_cache("QQQ", ib_data_fetcher, previous_days=10, use_rth=True)
-df = load_and_cache("SPY", ib_data_fetcher, previous_days=10, use_rth=True)
+symbols = ["SPY", "QQQ", "AAPL"]
+
+for symbol in symbols:
+    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15)
+    logger.info(f"{symbol} - {len(df.index)}")

--- a/examples/example_db_stocks.py
+++ b/examples/example_db_stocks.py
@@ -6,5 +6,7 @@ ib_data_fetcher = IbDataFetcher()
 symbols = ["SPY", "QQQ", "AAPL"]
 
 for symbol in symbols:
-    df = load_and_cache(symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15)
+    df = load_and_cache(
+        symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15
+    )
     logger.info(f"{symbol} - {len(df.index)}")

--- a/ta_scanner/data.py
+++ b/ta_scanner/data.py
@@ -60,17 +60,17 @@ class Calendar(Enum):
         return {
             Calendar.CME: [
                 # equities
-                '/ES', '/MES', '/MNQ', '/NQ', '/MNQ'
+                '/ES', '/MES', '/MNQ', '/NQ', '/MNQ',
                 # metals
                 '/GC', '/MGC',
-                # metals
+                # energy
                 '/CL', '/QM',
                 # currencies
                 '/M6A', '/M6B', '/M6E',
                 # interest rates 
                 '/GE', '/ZN', '/ZN', '/ZT',
                 # grains
-                '/ZC', '/YC', '/ZS', '/YK', '/ZW', '/YW'
+                '/ZC', '/YC', '/ZS', '/YK', '/ZW', '/YW',
             ],
             Calendar.CBOE: [],
             Calendar.ICE: [],
@@ -81,7 +81,7 @@ class Calendar(Enum):
         for k, v in Calendar.futures_lookup_hash().items():
             if symbol in v:
                 return k
-        logger.waring(f"Did not find a calendar entry for symbol={symbol}")
+        logger.warning(f"Did not find a calendar entry for symbol={symbol}")
         return Calendar.DEFAULT
 
     @staticmethod

--- a/ta_scanner/data.py
+++ b/ta_scanner/data.py
@@ -46,10 +46,9 @@ class Exchange(Enum):
     ICE = "ICE"
 
 
-
 class Calendar(Enum):
     # https://github.com/quantopian/trading_calendars
-    DEFAULT = "XNYS" # default to NYSE
+    DEFAULT = "XNYS"  # default to NYSE
     NYSE = "XNYS"
     CME = "CMES"
     CBOE = "XCBF"
@@ -60,17 +59,33 @@ class Calendar(Enum):
         return {
             Calendar.CME: [
                 # equities
-                '/ES', '/MES', '/MNQ', '/NQ', '/MNQ',
+                "/ES",
+                "/MES",
+                "/MNQ",
+                "/NQ",
+                "/MNQ",
                 # metals
-                '/GC', '/MGC',
+                "/GC",
+                "/MGC",
                 # energy
-                '/CL', '/QM',
+                "/CL",
+                "/QM",
                 # currencies
-                '/M6A', '/M6B', '/M6E',
-                # interest rates 
-                '/GE', '/ZN', '/ZN', '/ZT',
+                "/M6A",
+                "/M6B",
+                "/M6E",
+                # interest rates
+                "/GE",
+                "/ZN",
+                "/ZN",
+                "/ZT",
                 # grains
-                '/ZC', '/YC', '/ZS', '/YK', '/ZW', '/YW',
+                "/ZC",
+                "/YC",
+                "/ZS",
+                "/YK",
+                "/ZW",
+                "/YW",
             ],
             Calendar.CBOE: [],
             Calendar.ICE: [],
@@ -152,14 +167,18 @@ class IbDataFetcher(DataFetcherBase):
         d = {
             Exchange.GLOBEX: [
                 # equities
-                '/ES', '/MES', '/MNQ', '/NQ', '/MNQ'
+                "/ES",
+                "/MES",
+                "/MNQ",
+                "/NQ",
+                "/MNQ"
                 # # currencies
                 # ? '/M6A', '/M6B', '/M6E',
-                # # interest rates 
+                # # interest rates
                 # ? '/GE', '/ZN', '/ZN', '/ZT',
             ],
-            Exchange.ECBOT: ['/ZC', '/YC', '/ZS', '/YK', '/ZW', '/YW'],
-            Exchange.NYMEX: ['/GC', '/MGC', '/CL', '/QM',],
+            Exchange.ECBOT: ["/ZC", "/YC", "/ZS", "/YK", "/ZW", "/YW"],
+            Exchange.NYMEX: ["/GC", "/MGC", "/CL", "/QM",],
         }
 
         for k, v in d.items():
@@ -203,7 +222,7 @@ def extract_kwarg(kwargs: Dict, key: str, default_value: Any = None) -> Optional
     if key in kwargs:
         return kwargs[key]
     else:
-        return default_value        
+        return default_value
 
 
 def load_and_cache(
@@ -324,10 +343,10 @@ def aggregate_bars(df: pd.DataFrame, groupby_minutes: int) -> pd.DataFrame:
     if groupby_minutes == 1:
         return df
 
-    # this method only intended to handle data that's 
+    # this method only intended to handle data that's
     # aggredating data at intervals less than 1 day
     assert groupby_minutes < 1440
-    
+
     groupby = f"{groupby_minutes}min"
 
     agg_expression = {
@@ -343,7 +362,7 @@ def aggregate_bars(df: pd.DataFrame, groupby_minutes: int) -> pd.DataFrame:
 
 
 def transform_set_index_ts(df: pd.DataFrame) -> None:
-    df.set_index('ts', inplace=True)
+    df.set_index("ts", inplace=True)
 
 
 def transform_rename_df_columns(df) -> None:

--- a/ta_scanner/data.py
+++ b/ta_scanner/data.py
@@ -227,6 +227,7 @@ def load_and_cache(
     use_rth = extract_kwarg(kwargs, "use_rth", False)
     contract_date = extract_kwarg(kwargs, "contract_date")
     groupby_minutes = extract_kwarg(kwargs, "groupby_minutes", 1)
+    return_tz = extract_kwarg(kwargs, "return_tz", TimezoneNames.US_EASTERN.value)
 
     tz = pytz.timezone(TimezoneNames.US_EASTERN.value)
     now = datetime.now(tz)
@@ -271,6 +272,7 @@ def load_and_cache(
         transform_set_index_ts(df)
 
         df = aggregate_bars(df, groupby_minutes)
+        transform_ts_result_tz(df, return_tz)
 
         logger.debug(f"--- fetched {instrument_symbol} - {date.strftime('%Y-%m-%d')}")
 
@@ -346,6 +348,11 @@ def transform_set_index_ts(df: pd.DataFrame) -> None:
 
 def transform_rename_df_columns(df) -> None:
     df.rename(columns={"date": "ts", "barCount": "bar_count"}, inplace=True)
+
+
+def transform_ts_result_tz(df: pd.DataFrame, return_tz: str) -> None:
+    return_tz_value = pytz.timezone(return_tz)
+    df.index = df.index.tz_convert(return_tz_value)
 
 
 def clean_query(query: str) -> str:

--- a/ta_scanner/filters.py
+++ b/ta_scanner/filters.py
@@ -55,7 +55,7 @@ class FilterCumsum(BaseFitler):
         df: pd.DataFrame,
         field_name: str,
         filter_options: Dict[FilterOptions, Any],
-        inverse: int = 1
+        inverse: int = 1,
     ):
         self.ensure_required_filter_options(
             self.required_filter_options, filter_options
@@ -95,4 +95,3 @@ class FilterCumsum(BaseFitler):
                 if index_after == threshold - 1:
                     self.log_exit("MaxTime", diff, df.loc[df_index])
                     df.at[df_index, self.name] = diff
-                

--- a/ta_scanner/indicators.py
+++ b/ta_scanner/indicators.py
@@ -34,9 +34,10 @@ class BaseIndicator(metaclass=abc.ABCMeta):
     def ensure_required_filter_options(
         self, expected: List[IndicatorParams], actual: Dict[IndicatorParams, Any]
     ):
-        for fo_key in expected:
-            if fo_key not in actual:
-                raise IndicatorException(f"expected this key = {fo_key}")
+        for expected_key in expected:
+            if expected_key not in actual:
+                indicator_name = self.__class__.__name__
+                raise IndicatorException(f"{indicator_name} requires key = {expected_key}")
 
     @abc.abstractmethod
     def apply(self, df, field_name: str) -> None:

--- a/ta_scanner/indicators.py
+++ b/ta_scanner/indicators.py
@@ -37,7 +37,9 @@ class BaseIndicator(metaclass=abc.ABCMeta):
         for expected_key in expected:
             if expected_key not in actual:
                 indicator_name = self.__class__.__name__
-                raise IndicatorException(f"{indicator_name} requires key = {expected_key}")
+                raise IndicatorException(
+                    f"{indicator_name} requires key = {expected_key}"
+                )
 
     @abc.abstractmethod
     def apply(self, df, field_name: str) -> None:

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 from typing import Any, Dict
 
-from ta_scanner.indicators import IndicatorSmaCrossover
+from ta_scanner.indicators import IndicatorSmaCrossover, IndicatorParams, IndicatorException
 
 
 def gen_df_zeros(field_name="some_field_name"):
@@ -11,3 +11,22 @@ def gen_df_zeros(field_name="some_field_name"):
 
 def test_abstract_methods_present():
     IndicatorSmaCrossover()
+
+
+def test_ensure_required_filter_options():
+    sma_crossover = IndicatorSmaCrossover()
+
+    fake_df = gen_df_zeros()
+    fake_field_name = "fake_some_name"
+
+    params = {
+        IndicatorParams.fast_sma: 20,
+        # IndicatorParams.slow_sma: 50, # intentionally missing param
+    }
+
+    with pytest.raises(IndicatorException) as e:
+        sma_crossover.apply(fake_df, fake_field_name, params=params)
+
+    expected_message = 'IndicatorSmaCrossover requires key = IndicatorParams.slow_sma'
+    assert expected_message == str(e.value)
+

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -2,7 +2,11 @@ import pandas as pd
 import pytest
 from typing import Any, Dict
 
-from ta_scanner.indicators import IndicatorSmaCrossover, IndicatorParams, IndicatorException
+from ta_scanner.indicators import (
+    IndicatorSmaCrossover,
+    IndicatorParams,
+    IndicatorException,
+)
 
 
 def gen_df_zeros(field_name="some_field_name"):
@@ -27,6 +31,5 @@ def test_ensure_required_filter_options():
     with pytest.raises(IndicatorException) as e:
         sma_crossover.apply(fake_df, fake_field_name, params=params)
 
-    expected_message = 'IndicatorSmaCrossover requires key = IndicatorParams.slow_sma'
+    expected_message = "IndicatorSmaCrossover requires key = IndicatorParams.slow_sma"
     assert expected_message == str(e.value)
-


### PR DESCRIPTION
## Expected Behavior
The focus is that we want to aggregate minute data into variable timeframe bars (eg, 1m ... 1440m).

Data should still be stored at 1 minute increments in the DB. When data returned as a dataframe, transform into the desired timeframe bars.

For data greater than 1440 minute in duration, cache in a separate table (this will be in a follow up ticket).