### PR TITLE
data/load- choose start date

### DIFF
--- a/examples/db_futures.py
+++ b/examples/db_futures.py
@@ -1,6 +1,6 @@
 from loguru import logger
 from ta_scanner.data import load_and_cache, IbDataFetcher
-
+import datetime
 
 ib_data_fetcher = IbDataFetcher()
 
@@ -8,7 +8,12 @@ future_symbols = ["/MES", "/MNQ", "/ZS", "/GC"]
 
 for symbol in future_symbols:
     df = load_and_cache(
-        symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=1
+        symbol,
+        ib_data_fetcher,
+        start_date=datetime.date(2020, 7, 10),
+        end_date=datetime.date(2020, 7, 20),
+        use_rth=False,
+        groupby_minutes=1,
     )
     logger.info(f"{symbol} - {len(df.index)}")
     logger.info(f"{symbol} - first data row = {df.head(1)}")
@@ -17,7 +22,8 @@ for symbol in future_symbols:
     df = load_and_cache(
         symbol,
         ib_data_fetcher,
-        previous_days=20,
+        start_date=datetime.date(2020, 7, 10),
+        end_date=datetime.date(2020, 7, 20),
         use_rth=False,
         groupby_minutes=1,
         return_tz="US/Mountain",

--- a/examples/db_stocks.py
+++ b/examples/db_stocks.py
@@ -1,3 +1,4 @@
+from datetime import date
 from loguru import logger
 from ta_scanner.data import load_and_cache, IbDataFetcher
 
@@ -7,6 +8,11 @@ symbols = ["SPY", "QQQ", "AAPL"]
 
 for symbol in symbols:
     df = load_and_cache(
-        symbol, ib_data_fetcher, previous_days=20, use_rth=False, groupby_minutes=15
+        symbol,
+        ib_data_fetcher,
+        start_date=date(2020, 6, 1),
+        end_date=date(2020, 6, 30),
+        use_rth=False,
+        groupby_minutes=15,
     )
     logger.info(f"{symbol} - {len(df.index)}")

--- a/examples/moving_average_crossover_futures.py
+++ b/examples/moving_average_crossover_futures.py
@@ -1,4 +1,6 @@
+from datetime import datetime, date
 from loguru import logger
+
 from ta_scanner.data import load_and_cache, IbDataFetcher
 from ta_scanner.indicators import IndicatorSmaCrossover, IndicatorParams
 from ta_scanner.signals import Signal
@@ -6,9 +8,14 @@ from ta_scanner.filters import FilterCumsum, FilterOptions, FilterNames
 from ta_scanner.reports import BasicReport
 
 
-# get SPY data
 ib_data_fetcher = IbDataFetcher()
-df = load_and_cache("/MES", ib_data_fetcher, previous_days=7, use_rth=True)
+df = load_and_cache(
+    "/MES",
+    ib_data_fetcher,
+    start_date=date(2020, 7, 10),
+    end_date=date(2020, 7, 20),
+    use_rth=True,
+)
 
 indicator_sma_cross = IndicatorSmaCrossover()
 

--- a/examples/moving_average_crossover_range_futures.py
+++ b/examples/moving_average_crossover_range_futures.py
@@ -1,3 +1,4 @@
+from datetime import date
 from loguru import logger
 import sys
 
@@ -15,7 +16,13 @@ logger.add(sys.stderr, level="INFO")
 ib_data_fetcher = IbDataFetcher()
 
 symbol = "/MGC"
-df_original = load_and_cache(symbol, ib_data_fetcher, previous_days=7, use_rth=True)
+df_original = load_and_cache(
+    symbol,
+    ib_data_fetcher,
+    start_date=date(2020, 7, 1),
+    end_date=date(2020, 7, 20),
+    use_rth=True,
+)
 
 indicator_sma_cross = IndicatorSmaCrossover()
 
@@ -67,7 +74,7 @@ headers = ["slow_sma", "fast_sma", "pnl", "count", "avg", "median"]
 
 filename = f"results/MA_Crx_{symbol.replace('/', '')}.csv"
 
-with open(filename, 'w') as f:
+with open(filename, "w") as f:
     import csv
 
     writer = csv.writer(f)

--- a/examples/moving_average_crossover_range_stocks.py
+++ b/examples/moving_average_crossover_range_stocks.py
@@ -1,3 +1,4 @@
+from datetime import date
 from loguru import logger
 import sys
 
@@ -14,7 +15,13 @@ logger.add(sys.stderr, level="INFO")
 
 # get SPY data
 ib_data_fetcher = IbDataFetcher()
-df_original = load_and_cache("SPY", ib_data_fetcher, previous_days=30, use_rth=True)
+df_original = load_and_cache(
+    "SPY",
+    ib_data_fetcher,
+    start_date=date(2020, 7, 1),
+    end_date=date(2020, 7, 20),
+    use_rth=True,
+)
 
 indicator_sma_cross = IndicatorSmaCrossover()
 

--- a/examples/moving_average_crossover_stocks.py
+++ b/examples/moving_average_crossover_stocks.py
@@ -8,7 +8,13 @@ from ta_scanner.reports import BasicReport
 
 # get SPY data
 ib_data_fetcher = IbDataFetcher()
-df = load_and_cache("SPY", ib_data_fetcher, previous_days=30, use_rth=True)
+df = load_and_cache(
+    "SPY",
+    ib_data_fetcher,
+    start_date=date(2020, 7, 1),
+    end_date=date(2020, 7, 20),
+    use_rth=True,
+)
 
 indicator_sma_cross = IndicatorSmaCrossover()
 


### PR DESCRIPTION
Currently `load_and_cache` pulls data looking for the last x days (via the `previous_days` config param). Let's change this so that a developer can configure dfs per, 
- previous_days (int)
- start_date (date), end_date (date) 